### PR TITLE
Update to set the player lives to zero at end of game

### DIFF
--- a/3_feed_the_dragon/feed_the_dragon.py
+++ b/3_feed_the_dragon/feed_the_dragon.py
@@ -116,6 +116,7 @@ while running:
     if player_lives == 0:
         display_surface.blit(game_over_text, game_over_rect)
         display_surface.blit(continue_text, continue_rect)
+        display_surface.blit(lives_text, lives_rect)
         pygame.display.update()
 
         #Pause the game until player presses a key, then reset the game


### PR DESCRIPTION
When you have completed a game and the player is deciding to whether to play another game of "Feed the Dragon", the lives count in the HUD shows 1. This patch corrects that problem and sets lives to zero.